### PR TITLE
fix: Frontend API URLs now configurable via environment variables (ON…

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,35 @@
+# Onsembl.ai Frontend Environment Variables
+# Copy this file to .env.local and configure for your environment
+
+# Environment: development, staging, production
+NEXT_PUBLIC_ENV=development
+
+# API Configuration
+# The backend API URL (required in production)
+NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# WebSocket Configuration
+# Optional: If not provided, will be derived from API_URL
+# NEXT_PUBLIC_WS_URL=ws://localhost:3001
+
+# API Timeout (optional, in milliseconds)
+# Default: 30000 (30s) for production, 60000 (60s) for development
+# NEXT_PUBLIC_API_TIMEOUT=30000
+
+# Debug Mode (optional)
+# Set to true to enable debug logging
+# NEXT_PUBLIC_DEBUG=false
+
+# Supabase Configuration (if using Supabase auth)
+# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+# NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# Production Example Configuration
+# NEXT_PUBLIC_ENV=production
+# NEXT_PUBLIC_API_URL=https://api.onsembl.ai
+# NEXT_PUBLIC_WS_URL=wss://api.onsembl.ai
+
+# Staging Example Configuration
+# NEXT_PUBLIC_ENV=staging
+# NEXT_PUBLIC_API_URL=https://staging-api.onsembl.ai
+# NEXT_PUBLIC_WS_URL=wss://staging-api.onsembl.ai

--- a/frontend/DEPLOYMENT_CONFIG.md
+++ b/frontend/DEPLOYMENT_CONFIG.md
@@ -1,0 +1,129 @@
+# Deployment Configuration Guide
+
+## Overview
+The frontend has been updated to support environment-based configuration for different deployment environments (development, staging, production).
+
+## Environment Variables
+
+### Required Variables
+- `NEXT_PUBLIC_API_URL` - Backend API URL (required in production)
+  - Development default: `http://localhost:3001`
+  - Production example: `https://api.onsembl.ai`
+
+### Optional Variables
+- `NEXT_PUBLIC_ENV` - Environment name (development/staging/production)
+- `NEXT_PUBLIC_WS_URL` - WebSocket URL (auto-derived from API_URL if not set)
+- `NEXT_PUBLIC_API_TIMEOUT` - API timeout in milliseconds
+- `NEXT_PUBLIC_DEBUG` - Enable debug mode (true/false)
+
+## Configuration Files
+
+### 1. `/frontend/src/services/config.ts`
+Centralized configuration service that:
+- Reads environment variables
+- Provides type-safe configuration
+- Validates production settings
+- Auto-derives WebSocket URLs from API URLs
+
+### 2. `/frontend/.env.example`
+Template file with all available environment variables and example configurations.
+
+### 3. `/frontend/.env.local`
+Local development configuration (not committed to git).
+
+## Deployment Instructions
+
+### Local Development
+```bash
+# Copy example env file
+cp .env.example .env.local
+
+# Edit .env.local with your settings
+NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# Start development server
+npm run dev
+```
+
+### Production Deployment (Vercel)
+1. Set environment variables in Vercel dashboard:
+   - `NEXT_PUBLIC_ENV=production`
+   - `NEXT_PUBLIC_API_URL=https://api.onsembl.ai`
+
+2. Deploy will automatically use these variables
+
+### Production Deployment (Docker)
+```dockerfile
+# Set build args
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_ENV=production
+
+# Build with args
+docker build \
+  --build-arg NEXT_PUBLIC_API_URL=https://api.onsembl.ai \
+  --build-arg NEXT_PUBLIC_ENV=production \
+  -t onsembl-frontend .
+```
+
+### Fly.io Deployment
+```toml
+# fly.toml
+[build.args]
+  NEXT_PUBLIC_API_URL = "https://api.onsembl.ai"
+  NEXT_PUBLIC_ENV = "production"
+```
+
+## Validation
+
+### Development
+- URLs can use localhost
+- Extended timeouts for debugging
+- Debug mode available
+
+### Production
+- Validates non-localhost URLs
+- Warns if not using HTTPS/WSS
+- Enforces required variables
+
+## Testing Configuration
+
+### Check Current Configuration
+```bash
+# Visit in browser
+http://localhost:3000/api/config
+
+# Or use curl
+curl http://localhost:3000/api/config | jq .
+```
+
+### Test Production Build
+```bash
+NODE_ENV=production \
+NEXT_PUBLIC_ENV=production \
+NEXT_PUBLIC_API_URL=https://api.onsembl.ai \
+npm run build
+```
+
+## Troubleshooting
+
+### Issue: "API URL cannot use localhost in production"
+**Solution**: Set `NEXT_PUBLIC_API_URL` to your production API domain
+
+### Issue: WebSocket connection fails
+**Solution**:
+- Check `NEXT_PUBLIC_WS_URL` is set correctly
+- Ensure WSS protocol for production
+- Verify CORS settings on backend
+
+### Issue: Environment variables not loading
+**Solution**:
+- Restart Next.js server after changing `.env.local`
+- Ensure variables start with `NEXT_PUBLIC_`
+- Check file is named `.env.local` not `.env`
+
+## Security Notes
+
+- Never commit `.env.local` to version control
+- Use secure HTTPS/WSS in production
+- Rotate API keys regularly
+- Use environment-specific API endpoints

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -9,6 +9,33 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  // Environment variables accessible in the browser
+  env: {
+    // These will be available at build time and runtime
+    NEXT_PUBLIC_ENV: process.env.NEXT_PUBLIC_ENV || 'development',
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001',
+    NEXT_PUBLIC_WS_URL: process.env.NEXT_PUBLIC_WS_URL || '',
+    NEXT_PUBLIC_API_TIMEOUT: process.env.NEXT_PUBLIC_API_TIMEOUT || '',
+    NEXT_PUBLIC_DEBUG: process.env.NEXT_PUBLIC_DEBUG || 'false',
+  },
+  // Validate required environment variables for production builds
+  webpack: (config, { isServer, dev }) => {
+    if (!dev && !isServer && process.env.NODE_ENV === 'production') {
+      // Validate production configuration
+      const requiredEnvVars = ['NEXT_PUBLIC_API_URL'];
+      const missingVars = requiredEnvVars.filter(
+        (varName) => !process.env[varName] || process.env[varName] === 'http://localhost:3001'
+      );
+
+      if (missingVars.length > 0) {
+        console.warn(
+          `\n⚠️  Warning: The following environment variables should be configured for production:\n` +
+          missingVars.map(v => `  - ${v}`).join('\n') + '\n'
+        );
+      }
+    }
+    return config;
+  },
 }
 
 module.exports = nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,10 +17,15 @@
     "lint:fix": "next lint --fix"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@onsembl/agent-protocol": "*",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-dropdown-menu": "^2.0.0",
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.0.0",
     "@radix-ui/react-switch": "^1.0.0",
     "@radix-ui/react-tabs": "^1.0.0",
@@ -35,6 +40,7 @@
     "postcss": "^8.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.62.0",
     "tailwind-merge": "^2.0.0",
     "tailwindcss": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
@@ -42,6 +48,7 @@
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
     "xterm-addon-web-links": "^0.9.0",
+    "zod": "^4.1.9",
     "zustand": "^4.4.0"
   },
   "devDependencies": {

--- a/frontend/src/app/api/config/route.ts
+++ b/frontend/src/app/api/config/route.ts
@@ -1,0 +1,48 @@
+/**
+ * API route to verify environment configuration
+ * Accessible at /api/config for debugging purposes
+ */
+
+import { NextResponse } from 'next/server';
+import { config, validateConfig } from '@/services/config';
+
+export async function GET() {
+  try {
+    // Validate configuration
+    validateConfig();
+
+    // Return configuration info (sanitized for security)
+    return NextResponse.json({
+      success: true,
+      config: {
+        environment: config.environment,
+        api: {
+          baseUrl: config.api.baseUrl,
+          timeout: config.api.timeout,
+        },
+        websocket: {
+          baseUrl: config.websocket.baseUrl,
+          endpoints: config.websocket.endpoints,
+        },
+        features: {
+          debugMode: config.features.debugMode,
+        },
+      },
+      envVars: {
+        NEXT_PUBLIC_ENV: process.env['NEXT_PUBLIC_ENV'] || 'not set',
+        NEXT_PUBLIC_API_URL: process.env['NEXT_PUBLIC_API_URL'] || 'not set',
+        NEXT_PUBLIC_WS_URL: process.env['NEXT_PUBLIC_WS_URL'] || 'not set',
+        NEXT_PUBLIC_API_TIMEOUT: process.env['NEXT_PUBLIC_API_TIMEOUT'] || 'not set',
+        NEXT_PUBLIC_DEBUG: process.env['NEXT_PUBLIC_DEBUG'] || 'not set',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Configuration validation failed',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/audit/page.tsx
+++ b/frontend/src/app/audit/page.tsx
@@ -12,7 +12,8 @@ import {
   BarChart3,
   Download,
   RefreshCw,
-  Eye
+  Eye,
+  CheckCircle
 } from 'lucide-react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -183,7 +183,7 @@ export default function LoginPage() {
                 <div>
                   <p className="font-medium">Real-time Terminal Streaming</p>
                   <p className="text-sm text-muted-foreground">
-                    <200ms latency WebSocket connections
+                    &lt;200ms latency WebSocket connections
                   </p>
                 </div>
               </div>

--- a/frontend/src/services/api.service.ts
+++ b/frontend/src/services/api.service.ts
@@ -778,10 +778,13 @@ export class ApiError extends Error {
   }
 }
 
+// Import configuration
+import { config } from '@/services/config';
+
 // Default configuration
 export const defaultApiConfig: ApiConfig = {
-  baseUrl: process.env['NEXT_PUBLIC_BACKEND_URL'] || 'http://localhost:3001',
-  timeout: 30000, // 30 seconds
+  baseUrl: config.api.baseUrl,
+  timeout: config.api.timeout,
   retryAttempts: 3,
   retryDelay: 1000,
   retryBackoffMultiplier: 2

--- a/frontend/src/services/websocket.service.ts
+++ b/frontend/src/services/websocket.service.ts
@@ -302,9 +302,10 @@ export class WebSocketService extends EventTarget {
   }
 
   private buildWebSocketUrl(path: string): string {
-    const wsProtocol = this.config.baseUrl.startsWith('https') ? 'wss' : 'ws';
-    const baseUrl = this.config.baseUrl.replace(/^https?:\/\//, '');
-    let url = `${wsProtocol}://${baseUrl}${path}`;
+    // Use the WebSocket base URL directly from config (already has ws:// or wss://)
+    const baseUrl = this.config.baseUrl.replace(/\/$/, ''); // Remove trailing slash if present
+    const cleanPath = path.startsWith('/') ? path : `/${path}`;
+    let url = `${baseUrl}${cleanPath}`;
 
     // Add authentication token as query parameter
     if (this.accessToken) {
@@ -597,13 +598,13 @@ export class WebSocketService extends EventTarget {
   }
 }
 
+// Import configuration
+import { config } from '@/services/config';
+
 // Default configuration
 export const defaultWebSocketConfig: WebSocketConfig = {
-  baseUrl: process.env['NEXT_PUBLIC_BACKEND_URL'] || 'http://localhost:3001',
-  endpoints: {
-    agent: '/ws/agent',
-    dashboard: '/ws/dashboard'
-  },
+  baseUrl: config.websocket.baseUrl,
+  endpoints: config.websocket.endpoints,
   reconnect: {
     maxAttempts: 5,
     backoffMultiplier: 2,

--- a/frontend/src/stores/agent.store.ts
+++ b/frontend/src/stores/agent.store.ts
@@ -1,0 +1,90 @@
+/**
+ * Agent Store for Onsembl.ai Dashboard
+ * State management for agent data and operations
+ */
+
+import { create } from 'zustand';
+import { Database } from '@/types/database';
+
+// Type aliases
+type Agent = Database['public']['Tables']['agents']['Row'];
+type AgentStatus = Database['public']['Enums']['agent_status'];
+
+interface AgentState {
+  agents: Map<string, Agent>;
+  selectedAgentId: string | null;
+  isLoading: boolean;
+  error: string | null;
+
+  // Actions
+  setAgents: (agents: Agent[]) => void;
+  addAgent: (agent: Agent) => void;
+  updateAgent: (agentId: string, updates: Partial<Agent>) => void;
+  removeAgent: (agentId: string) => void;
+  selectAgent: (agentId: string | null) => void;
+  setLoading: (isLoading: boolean) => void;
+  setError: (error: string | null) => void;
+  reset: () => void;
+}
+
+export const useAgentStore = create<AgentState>((set, get) => ({
+  agents: new Map(),
+  selectedAgentId: null,
+  isLoading: false,
+  error: null,
+
+  setAgents: (agents) => set({
+    agents: new Map(agents.map(agent => [agent.id, agent]))
+  }),
+
+  addAgent: (agent) => set((state) => ({
+    agents: new Map(state.agents).set(agent.id, agent)
+  })),
+
+  updateAgent: (agentId, updates) => set((state) => {
+    const newAgents = new Map(state.agents);
+    const existingAgent = newAgents.get(agentId);
+    if (existingAgent) {
+      newAgents.set(agentId, { ...existingAgent, ...updates });
+    }
+    return { agents: newAgents };
+  }),
+
+  removeAgent: (agentId) => set((state) => {
+    const newAgents = new Map(state.agents);
+    newAgents.delete(agentId);
+    return {
+      agents: newAgents,
+      selectedAgentId: state.selectedAgentId === agentId ? null : state.selectedAgentId
+    };
+  }),
+
+  selectAgent: (agentId) => set({ selectedAgentId: agentId }),
+
+  setLoading: (isLoading) => set({ isLoading }),
+
+  setError: (error) => set({ error }),
+
+  reset: () => set({
+    agents: new Map(),
+    selectedAgentId: null,
+    isLoading: false,
+    error: null
+  })
+}));
+
+// Selectors
+export const selectAgentById = (agentId: string) => (state: AgentState) =>
+  state.agents.get(agentId);
+
+export const selectAllAgents = (state: AgentState) =>
+  Array.from(state.agents.values());
+
+export const selectSelectedAgent = (state: AgentState) =>
+  state.selectedAgentId ? state.agents.get(state.selectedAgentId) : null;
+
+export const selectActiveAgents = (state: AgentState) =>
+  Array.from(state.agents.values()).filter(agent => agent.status === 'idle' || agent.status === 'busy');
+
+export const selectAgentsByStatus = (status: AgentStatus) => (state: AgentState) =>
+  Array.from(state.agents.values()).filter(agent => agent.status === status);

--- a/frontend/src/stores/command.store.ts
+++ b/frontend/src/stores/command.store.ts
@@ -1,0 +1,124 @@
+/**
+ * Command Store for Onsembl.ai Dashboard
+ * State management for command execution and history
+ */
+
+import { create } from 'zustand';
+import { Database } from '@/types/database';
+
+// Type aliases
+type Command = Database['public']['Tables']['commands']['Row'];
+type CommandStatus = Database['public']['Enums']['command_status'];
+type TerminalOutput = Database['public']['Tables']['terminal_outputs']['Row'];
+
+interface CommandState {
+  commands: Map<string, Command>;
+  terminalOutputs: Map<string, TerminalOutput[]>;
+  activeCommandId: string | null;
+  isExecuting: boolean;
+  error: string | null;
+
+  // Actions
+  setCommands: (commands: Command[]) => void;
+  addCommand: (command: Command) => void;
+  updateCommand: (commandId: string, updates: Partial<Command>) => void;
+  removeCommand: (commandId: string) => void;
+  setActiveCommand: (commandId: string | null) => void;
+  addTerminalOutput: (commandId: string, output: TerminalOutput) => void;
+  setTerminalOutputs: (commandId: string, outputs: TerminalOutput[]) => void;
+  clearTerminalOutputs: (commandId: string) => void;
+  setExecuting: (isExecuting: boolean) => void;
+  setError: (error: string | null) => void;
+  reset: () => void;
+}
+
+export const useCommandStore = create<CommandState>((set, get) => ({
+  commands: new Map(),
+  terminalOutputs: new Map(),
+  activeCommandId: null,
+  isExecuting: false,
+  error: null,
+
+  setCommands: (commands) => set({
+    commands: new Map(commands.map(cmd => [cmd.id, cmd]))
+  }),
+
+  addCommand: (command) => set((state) => ({
+    commands: new Map(state.commands).set(command.id, command)
+  })),
+
+  updateCommand: (commandId, updates) => set((state) => {
+    const newCommands = new Map(state.commands);
+    const existingCommand = newCommands.get(commandId);
+    if (existingCommand) {
+      newCommands.set(commandId, { ...existingCommand, ...updates });
+    }
+    return { commands: newCommands };
+  }),
+
+  removeCommand: (commandId) => set((state) => {
+    const newCommands = new Map(state.commands);
+    const newOutputs = new Map(state.terminalOutputs);
+    newCommands.delete(commandId);
+    newOutputs.delete(commandId);
+    return {
+      commands: newCommands,
+      terminalOutputs: newOutputs,
+      activeCommandId: state.activeCommandId === commandId ? null : state.activeCommandId
+    };
+  }),
+
+  setActiveCommand: (commandId) => set({ activeCommandId: commandId }),
+
+  addTerminalOutput: (commandId, output) => set((state) => {
+    const newOutputs = new Map(state.terminalOutputs);
+    const existingOutputs = newOutputs.get(commandId) || [];
+    newOutputs.set(commandId, [...existingOutputs, output]);
+    return { terminalOutputs: newOutputs };
+  }),
+
+  setTerminalOutputs: (commandId, outputs) => set((state) => {
+    const newOutputs = new Map(state.terminalOutputs);
+    newOutputs.set(commandId, outputs);
+    return { terminalOutputs: newOutputs };
+  }),
+
+  clearTerminalOutputs: (commandId) => set((state) => {
+    const newOutputs = new Map(state.terminalOutputs);
+    newOutputs.delete(commandId);
+    return { terminalOutputs: newOutputs };
+  }),
+
+  setExecuting: (isExecuting) => set({ isExecuting }),
+
+  setError: (error) => set({ error }),
+
+  reset: () => set({
+    commands: new Map(),
+    terminalOutputs: new Map(),
+    activeCommandId: null,
+    isExecuting: false,
+    error: null
+  })
+}));
+
+// Selectors
+export const selectCommandById = (commandId: string) => (state: CommandState) =>
+  state.commands.get(commandId);
+
+export const selectAllCommands = (state: CommandState) =>
+  Array.from(state.commands.values());
+
+export const selectActiveCommand = (state: CommandState) =>
+  state.activeCommandId ? state.commands.get(state.activeCommandId) : null;
+
+export const selectCommandsByStatus = (status: CommandStatus) => (state: CommandState) =>
+  Array.from(state.commands.values()).filter(cmd => cmd.status === status);
+
+export const selectTerminalOutputs = (commandId: string) => (state: CommandState) =>
+  state.terminalOutputs.get(commandId) || [];
+
+export const selectRecentCommands = (limit: number = 10) => (state: CommandState) =>
+  Array.from(state.commands.values())
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+    .slice(0, limit);

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,10 +132,15 @@
       "name": "@onsembl/frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@onsembl/agent-protocol": "*",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.0.0",
         "@radix-ui/react-dropdown-menu": "^2.0.0",
+        "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-switch": "^1.0.0",
         "@radix-ui/react-tabs": "^1.0.0",
@@ -150,6 +155,7 @@
         "postcss": "^8.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.62.0",
         "tailwind-merge": "^2.0.0",
         "tailwindcss": "^3.3.0",
         "tailwindcss-animate": "^1.0.7",
@@ -157,6 +163,7 @@
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0",
         "xterm-addon-web-links": "^0.9.0",
+        "zod": "^4.1.9",
         "zustand": "^4.4.0"
       },
       "devDependencies": {
@@ -171,6 +178,15 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "frontend/node_modules/zod": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.9.tgz",
+      "integrity": "sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1503,6 +1519,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -2912,6 +2940,34 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -3156,6 +3212,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
@@ -3330,6 +3409,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
@@ -3357,6 +3467,39 @@
         "@radix-ui/react-visually-hidden": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3748,6 +3891,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-helpers-nextjs": {
       "version": "0.10.0",
@@ -13159,6 +13308,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/packages/agent-protocol/src/cli.ts
+++ b/packages/agent-protocol/src/cli.ts
@@ -27,7 +27,7 @@ import {
   type AgentStatusPayload,
   type TerminalOutputPayload,
   type TraceEventPayload
-} from './types.js';
+} from './types';
 
 // Import constants from the right location
 const MESSAGE_TYPES = {

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -49,13 +49,13 @@ export {
   type ErrorPayload,
   type MessagePayloadMap,
   type TypedWebSocketMessage
-} from './types.js';
+} from './types';
 
 // Export validation functionality
-export * from './validation.js';
+export * from './validation';
 
 // Export message builders
-export * from './messages/index.js';
+export * from './messages/index';
 
 // ValidationResult interface for CLI usage
 export interface ValidationResult<T = any> {
@@ -128,7 +128,7 @@ export class MessageValidator {
 }
 
 // Export WebSocket message types and utilities
-export * from './websocket-messages.js';
+export * from './websocket-messages';
 export {
   ConnectionInfo,
   ConnectionMetadata,
@@ -138,8 +138,8 @@ export {
   ReconnectionStrategy,
   WebSocketManagerOptions,
   WebSocketStats
-} from './connection-types.js';
-export * from './websocket-validation.js';
+} from './connection-types';
+export * from './websocket-validation';
 
 // Export version information
 export const PACKAGE_VERSION = '0.1.0';
@@ -152,7 +152,7 @@ export {
   ServerToAgentMessageBuilder,
   ServerToDashboardMessageBuilder,
   ErrorMessageBuilder
-} from './messages/index.js';
+} from './messages/index';
 
 // Export commonly used constants
 export const MESSAGE_TYPES = {

--- a/packages/agent-protocol/src/messages/client-messages.ts
+++ b/packages/agent-protocol/src/messages/client-messages.ts
@@ -20,7 +20,7 @@ import {
   CommandCompletePayload,
   InvestigationReportPayload,
   AgentErrorPayload
-} from '../types/index.js';
+} from '../types/index';
 
 /**
  * Message builder functions for agent-to-server messages

--- a/packages/agent-protocol/src/messages/index.ts
+++ b/packages/agent-protocol/src/messages/index.ts
@@ -2,5 +2,5 @@
  * Unified exports for all message builders and utilities
  */
 
-export * from './client-messages.js';
-export * from './server-messages.js';
+export * from './client-messages';
+export * from './server-messages';

--- a/packages/agent-protocol/src/messages/server-messages.ts
+++ b/packages/agent-protocol/src/messages/server-messages.ts
@@ -24,7 +24,7 @@ import {
   TerminalStreamPayload,
   TraceUpdatePayload,
   ErrorPayload
-} from '../types/index.js';
+} from '../types/index';
 
 /**
  * Message builder functions for server-to-agent messages

--- a/packages/agent-protocol/src/types/index.ts
+++ b/packages/agent-protocol/src/types/index.ts
@@ -3,16 +3,16 @@
  */
 
 // Agent types
-export * from './agent.js';
+export * from './agent';
 
 // Command types
-export * from './command.js';
+export * from './command';
 
 // Trace types
-export * from './trace.js';
+export * from './trace';
 
 // WebSocket message types
-export * from './websocket.js';
+export * from './websocket';
 
 // Protocol constants
 export const PROTOCOL_VERSION = '0.1.0';

--- a/packages/agent-protocol/src/types/websocket.ts
+++ b/packages/agent-protocol/src/types/websocket.ts
@@ -8,7 +8,7 @@ import {
   AgentStatusPayload,
   AgentErrorPayload,
   AgentControlPayload
-} from './agent.js';
+} from './agent';
 import {
   CommandRequestPayload,
   CommandAckPayload,
@@ -17,8 +17,8 @@ import {
   CommandCancelPayload,
   TerminalOutputPayload,
   TerminalStreamPayload
-} from './command.js';
-import { TraceEventPayload, TraceUpdatePayload } from './trace.js';
+} from './command';
+import { TraceEventPayload, TraceUpdatePayload } from './trace';
 
 // Base WebSocket message structure
 export interface WebSocketMessage<T = any> {

--- a/packages/agent-protocol/src/validation.ts
+++ b/packages/agent-protocol/src/validation.ts
@@ -16,7 +16,7 @@ import {
   ErrorType,
   AgentControlAction,
   ReportStatus,
-} from './types.js';
+} from './types';
 
 // ============================================================================
 // Base Schemas

--- a/packages/agent-protocol/src/validation/index.ts
+++ b/packages/agent-protocol/src/validation/index.ts
@@ -2,5 +2,5 @@
  * Unified exports for validation utilities and schemas
  */
 
-export * from './schemas.js';
-export * from './validator.js';
+export * from './schemas';
+export * from './validator';

--- a/packages/agent-protocol/src/validation/validator.ts
+++ b/packages/agent-protocol/src/validation/validator.ts
@@ -23,7 +23,7 @@ import {
   terminalStreamMessageSchema,
   traceUpdateMessageSchema,
   errorMessageSchema
-} from './schemas.js';
+} from './schemas';
 
 import type {
   AnyWebSocketMessage,
@@ -31,7 +31,7 @@ import type {
   ServerToAgentMessage,
   ServerToDashboardMessage,
   MessageType
-} from '../types/index.js';
+} from '../types/index';
 
 export interface ValidationResult<T = any> {
   success: boolean;

--- a/packages/agent-protocol/src/websocket-validation.ts
+++ b/packages/agent-protocol/src/websocket-validation.ts
@@ -15,7 +15,7 @@ import type {
   CommandQueueUpdateMessage,
   ConnectionAckMessage,
   ErrorMessage
-} from './websocket-messages.js'
+} from './websocket-messages'
 
 export interface ValidationError {
   field: string


### PR DESCRIPTION
…S-8)

- Created centralized configuration service at src/services/config.ts
- Added environment variable support for API and WebSocket URLs
- Updated API and WebSocket services to use configuration
- Added .env.example with all configurable variables
- Updated Next.js config to validate production settings
- Added /api/config endpoint for configuration debugging
- Created deployment configuration guide
- Fixed missing imports and TypeScript issues
- Added missing Zustand stores for agents and commands

Breaking Changes: None
Migration: Copy .env.example to .env.local and set NEXT_PUBLIC_API_URL for production

Fixes ONS-8