### PR TITLE
fix: Wire TokenManager to WebSocket handlers for JWT token refresh (O…

### DIFF
--- a/backend/src/websocket/token-manager.ts
+++ b/backend/src/websocket/token-manager.ts
@@ -344,14 +344,9 @@ export class TokenManager extends EventEmitter {
    */
   private async performTokenRefresh(token: TokenRecord): Promise<TokenRefreshPayload | null> {
     try {
-      if (!token.refreshToken) {
-        // If no refresh token, try to generate new one using current token
-        const result = await this.authService.refreshToken(token.currentToken);
-        return result;
-      }
-
-      // Use refresh token to get new access token
-      const result = await this.authService.refreshTokenWithRefreshToken(token.refreshToken);
+      // Always use refresh token if available, otherwise try with access token
+      const refreshToken = token.refreshToken || token.currentToken;
+      const result = await this.authService.refreshTokenWithRefreshToken(refreshToken);
       return result;
 
     } catch (error) {


### PR DESCRIPTION
…NS-10)

- Add validateToken and refreshTokenWithRefreshToken methods to AuthService
- Wire TokenManager to dashboard and agent WebSocket handlers
- Register tokens on connection and unregister on disconnect
- Update frontend WebSocket service to handle TOKEN_REFRESH messages
- Update agent-wrapper to handle TOKEN_REFRESH messages
- Simplify TokenManager's performTokenRefresh method

This ensures JWT tokens are automatically refreshed before expiry, preventing WebSocket connections from disconnecting after 1 hour. Tokens refresh 5 minutes before expiry with in-band refresh messages.

🤖 Generated with [Claude Code](https://claude.ai/code)