### PR TITLE
feat: Update authenticated navbar to match landing page design

### DIFF
--- a/frontend/src/components/layout/AuthenticatedLayout.tsx
+++ b/frontend/src/components/layout/AuthenticatedLayout.tsx
@@ -36,13 +36,13 @@ export function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
     <div className="flex flex-col h-screen w-full overflow-hidden bg-background">
       {/* Navigation Bar */}
       <Navbar
-        className="h-14 bg-background/95 backdrop-blur-sm border-b"
+        className="h-12 bg-zinc-950 border-b border-border"
         onLogout={handleLogout}
         showProjectTitle={true}
       />
 
       {/* Main content area with padding for fixed header */}
-      <div className="flex h-screen pt-14">
+      <div className="flex h-screen pt-12">
         {/* Enhanced Sidebar */}
         <EnhancedSidebar />
 

--- a/frontend/src/components/navigation/Navbar.tsx
+++ b/frontend/src/components/navigation/Navbar.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { cn } from '@/lib/utils';
 import { NavbarBrand } from './NavbarBrand';
 import { NavbarCenter } from './NavbarCenter';
@@ -25,25 +26,29 @@ export function Navbar({
 
   return (
     <header className={cn("fixed top-0 left-0 right-0 z-50 border-b border-border", className)}>
-      <nav className="w-full px-4">
-        <div className="flex h-14 items-center relative">
-          {/* Logo/Brand - absolutely positioned */}
-          <div className={cn("absolute left-0 flex items-center h-full", brandClassName)}>
+      <nav className="w-full px-4 sm:px-6 lg:px-8">
+        <div className="flex h-12 items-center relative">
+          {/* Logo/Brand - far left */}
+          <div className={cn("flex items-center h-full", brandClassName)}>
             <NavbarBrand />
           </div>
 
-          {/* Center Content */}
-          <NavbarCenter
-            isAuthenticated={isAuthenticated}
-            showProjectTitle={showProjectTitle}
-          />
+          {/* Center Content - absolutely centered */}
+          <div className="absolute left-1/2 transform -translate-x-1/2">
+            <NavbarCenter
+              isAuthenticated={isAuthenticated}
+              showProjectTitle={showProjectTitle}
+            />
+          </div>
 
-          {/* Right side controls */}
-          <NavbarActions
-            onOpenAuthModal={onOpenAuthModal}
-            onLogout={onLogout}
-            showDemoMenu={showDemoMenu}
-          />
+          {/* Right side controls - far right */}
+          <div className="ml-auto flex items-center h-full">
+            <NavbarActions
+              onOpenAuthModal={onOpenAuthModal}
+              onLogout={onLogout}
+              showDemoMenu={showDemoMenu}
+            />
+          </div>
         </div>
       </nav>
     </header>

--- a/frontend/src/components/navigation/NavbarActions.tsx
+++ b/frontend/src/components/navigation/NavbarActions.tsx
@@ -1,8 +1,7 @@
 import { useRouter, usePathname } from 'next/navigation';
-import { Edit, Palette, Wifi, WifiOff } from 'lucide-react';
+import { Edit, Palette } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { useProject } from '@/hooks/useProject';
-import { useUIStore } from '@/stores/ui-store';
 import { ThemeSelector } from './ThemeSelector';
 import { NavbarAuth } from './NavbarAuth';
 import { NavbarMenu } from './NavbarMenu';
@@ -18,7 +17,6 @@ export function NavbarActions({ onOpenAuthModal, onLogout, showDemoMenu = false 
   const pathname = usePathname();
   const { isAuthenticated } = useAuth();
   const { currentProject } = useProject();
-  const { webSocketState } = useUIStore();
 
   const isProjectPage = pathname?.startsWith('/project/');
   const isEditorPage = pathname?.includes('/editor');
@@ -35,33 +33,6 @@ export function NavbarActions({ onOpenAuthModal, onLogout, showDemoMenu = false 
 
   return (
     <div className="absolute right-0 flex items-center gap-2 h-full">
-      {/* WebSocket status indicator - only show when authenticated */}
-      {isAuthenticated && (
-        <div className="flex items-center space-x-1 px-2">
-          {webSocketState === 'connected' ? (
-            <>
-              <Wifi className="h-4 w-4 text-success" />
-              <span className="text-xs text-muted-foreground hidden sm:inline">Connected</span>
-            </>
-          ) : webSocketState === 'connecting' ? (
-            <>
-              <Wifi className="h-4 w-4 text-secondary animate-pulse" />
-              <span className="text-xs text-muted-foreground hidden sm:inline">Connecting</span>
-            </>
-          ) : webSocketState === 'error' ? (
-            <>
-              <WifiOff className="h-4 w-4 text-destructive" />
-              <span className="text-xs text-muted-foreground hidden sm:inline">Error</span>
-            </>
-          ) : (
-            <>
-              <WifiOff className="h-4 w-4 text-gray-500" />
-              <span className="text-xs text-muted-foreground hidden sm:inline">Offline</span>
-            </>
-          )}
-        </div>
-      )}
-
       {/* Demo Menu - show for demo pages or authenticated users */}
       {(showDemoMenu || isAuthenticated) && <NavbarMenu />}
 

--- a/frontend/src/components/navigation/NavbarBrand.tsx
+++ b/frontend/src/components/navigation/NavbarBrand.tsx
@@ -15,7 +15,7 @@ export function NavbarBrand({ className }: NavbarBrandProps) {
       )}
     >
       <span className="text-xl drop-shadow-sm">🪄</span>
-      <span className="text-foreground">Ensemble</span>
+      <span className="text-foreground">Onsembl</span>
     </Link>
   );
 }

--- a/frontend/src/components/navigation/NavbarCenter.tsx
+++ b/frontend/src/components/navigation/NavbarCenter.tsx
@@ -63,7 +63,7 @@ export function NavbarCenter({ isAuthenticated, showProjectTitle }: NavbarCenter
   // Show project title when authenticated and on a project page
   if (isAuthenticated && isProjectPage && currentProject && showProjectTitle) {
     return (
-      <div className="hidden md:flex items-center gap-8 mx-auto">
+      <div className="hidden md:flex items-center gap-8">
         <Popover open={isEditingProjectName} onOpenChange={setIsEditingProjectName}>
           <PopoverTrigger asChild>
             <button
@@ -111,21 +111,18 @@ export function NavbarCenter({ isAuthenticated, showProjectTitle }: NavbarCenter
     );
   }
 
-  // Show navigation links for non-project pages
-  if (!isProjectPage) {
+  // Show breadcrumb navigation for authenticated pages
+  if (isAuthenticated) {
     return (
-      <div className="hidden md:flex items-center gap-8 mx-auto h-full">
-        <span className="text-sm font-medium text-foreground/40 cursor-not-allowed transition-all duration-200 hover:text-foreground/60">
-          Features
+      <div className="hidden md:flex items-center gap-2 h-full">
+        <span className="text-sm font-medium text-zinc-300">
+          Workspace
         </span>
-        <span className="text-sm font-medium text-foreground/40 cursor-not-allowed transition-all duration-200 hover:text-foreground/60">
-          Learn
+        <span className="text-sm font-medium text-zinc-500">
+          &gt;
         </span>
-        <span className="text-sm font-medium text-foreground/40 cursor-not-allowed transition-all duration-200 hover:text-foreground/60">
-          Pricing
-        </span>
-        <span className="text-sm font-medium text-foreground/40 cursor-not-allowed transition-all duration-200 hover:text-foreground/60">
-          Enterprise
+        <span className="text-sm font-medium text-zinc-100">
+          All Agents
         </span>
       </div>
     );


### PR DESCRIPTION
- Update navbar background from backdrop-blur to solid zinc-950
- Adjust navbar height from h-14 to h-12 (48px) for better proportions
- Restructure layout with logo at far left, actions at far right
- Replace center navigation with breadcrumb-style "Workspace > All Agents"
- Remove WebSocket status indicator and connection text
- Fix brand name from "Ensemble" to "Onsembl"
- Maintain responsive design and proper vertical alignment

Addresses ONS-33 requirements for consistent design between landing page and authenticated layout.

🤖 Generated with [Claude Code](https://claude.ai/code)